### PR TITLE
Partly fixes #92 for my use case

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,29 @@
-include: package:pedantic/analysis_options.yaml
+# This file configures the analyzer, which statically analyzes Dart code to
+# check for errors, warnings, and lints.
+#
+# The issues identified by the analyzer are surfaced in the UI of Dart-enabled
+# IDEs (https://dart.dev/tools#ides-and-editors). The analyzer can also be
+# invoked from the command line by running `flutter analyze`.
+
+# The following line activates a set of recommended lints for Flutter apps,
+# packages, and plugins designed to encourage good coding practices.
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  # The lint rules applied to this project can be customized in the
+  # section below to disable rules from the `package:flutter_lints/flutter.yaml`
+  # included above or to enable additional rules. A list of all available lints
+  # and their documentation is published at
+  # https://dart-lang.github.io/linter/lints/index.html.
+  #
+  # Instead of disabling a lint rule for the entire project in the
+  # section below, it can also be suppressed for a single line of code
+  # or a specific dart file by using the `// ignore: name_of_lint` and
+  # `// ignore_for_file: name_of_lint` syntax on the line or in the file
+  # producing the lint.
+  rules:
+    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
+    # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
+
+# Additional information about this file can be found at
+# https://dart.dev/guides/language/analysis-options

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,14 +21,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -42,7 +42,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   csslib:
     dependency: transitive
     description:
@@ -56,14 +56,14 @@ packages:
       name: cupertino_icons
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.5"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -92,7 +92,7 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.0"
+    version: "0.13.4"
   http_parser:
     dependency: transitive
     description:
@@ -106,42 +106,42 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.4"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.10.0"
+    version: "1.8.1"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -153,7 +153,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -188,7 +188,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.9"
   typed_data:
     dependency: transitive
     description:
@@ -202,7 +202,21 @@ packages:
       name: url_launcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.0"
+    version: "6.1.5"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.17"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.17"
   url_launcher_linux:
     dependency: transitive
     description:
@@ -223,7 +237,7 @@ packages:
       name: url_launcher_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.0"
   url_launcher_web:
     dependency: transitive
     description:
@@ -244,7 +258,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   web_scraper:
     dependency: "direct main"
     description:
@@ -253,5 +267,5 @@ packages:
     source: path
     version: "0.1.4"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
-  flutter: ">=1.22.0"
+  dart: ">=2.17.0-0 <3.0.0"
+  flutter: ">=2.8.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -20,12 +20,12 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  web_scraper: 
+  web_scraper:
     path: ../
-  url_launcher: ^6.0.0
+  url_launcher: ^6.1.5
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.2
+  cupertino_icons: ^1.0.5
 
 dev_dependencies:
   flutter_test:

--- a/lib/web_scraper.dart
+++ b/lib/web_scraper.dart
@@ -156,6 +156,39 @@ class WebScraper {
     return result;
   }
 
+  /// Returns the first occurance of a variable in the script tags
+  ///
+  // ex. if document contains
+  // <script> var a = 15;</script>
+  // <script> var a = 9; </script>
+  // method will return 'var a = 15;'.
+  String getFirstScriptVariable(String variableName) {
+    // The _document should not be null (loadWebPage must be called before getScriptVariables).
+    assert(_document != null);
+
+    // Quering the list of elements by tag names.
+    var scripts = _document!.getElementsByTagName('script');
+
+    String result = '';
+
+    // Looping in all the script tags of the document.
+    for (var script in scripts) {
+      // Regular expression to get the variable name.
+      var re = RegExp(variableName + r""" *=.*?;(?=([^"']*"[^"']*")*[^"']*$)""",
+          multiLine: true);
+      //  Find first match
+      RegExpMatch? match = re.firstMatch(script.text);
+
+      if (match != null) {
+        result = match[0]!;
+        break;
+      }
+    }
+
+    // Returning final result
+    return result;
+  }
+
   /// Returns webpage's html in string format.
   String getPageContent() => _document != null
       ? _document!.outerHtml

--- a/lib/web_scraper.dart
+++ b/lib/web_scraper.dart
@@ -51,13 +51,13 @@ class WebScraper {
       var client = Client();
 
       try {
-        var _response = await client.get(Uri.parse(baseUrl! + route));
+        var response = await client.get(Uri.parse(baseUrl! + route));
         // Calculating Time Elapsed using timer from dart:core.
         timeElaspsed = stopwatch.elapsed.inMilliseconds;
         stopwatch.stop();
         stopwatch.reset();
         // Parses the response body once it's retrieved to be used on the other methods.
-        _document = parse(_response.body);
+        _document = parse(response.body);
       } catch (e) {
         throw WebScraperException(e.toString());
       }
@@ -71,10 +71,10 @@ class WebScraper {
   Future<bool> loadFullURL(String page) async {
     var client = Client();
     try {
-      var _response = await client.get(Uri.parse(page));
+      var response = await client.get(Uri.parse(page));
       // Calculating Time Elapsed using timer from dart:core.
       // Parses the response body once it's retrieved to be used on the other methods.
-      _document = parse(_response.body);
+      _document = parse(response.body);
     } catch (e) {
       throw WebScraperException(e.toString());
     }
@@ -134,11 +134,11 @@ class WebScraper {
       for (var variableName in variableNames) {
         // Regular expression to get the variable names.
         var re = RegExp(
-            '$variableName *=.*?;(?=([^\"\']*\"[^\"\']*\")*[^\"\']*\$)',
+            variableName + r""" *=.*?;(?=([^"']*"[^"']*")*[^"']*$)""",
             multiLine: true);
         //  Iterate all matches
         Iterable matches = re.allMatches(script.text);
-        matches.forEach((match) {
+        for (var match in matches) {
           if (match != null) {
             // List for all the occurence of the variable name.
             var temp = result[variableName];
@@ -148,7 +148,7 @@ class WebScraper {
             temp!.add(script.text.substring(match.start, match.end));
             result[variableName] = temp;
           }
-        });
+        }
       }
     }
 
@@ -254,7 +254,7 @@ class WebScraper {
 
 /// WebScraperException throws exception with specified message.
 class WebScraperException implements Exception {
-  var _message;
+  String? _message;
   WebScraperException(String? message) {
     _message = message;
   }

--- a/lib/web_scraper.dart
+++ b/lib/web_scraper.dart
@@ -186,7 +186,7 @@ class WebScraper {
     }
 
     // Returning final result
-    return result;
+    return result.trim();
   }
 
   /// Returns webpage's html in string format.

--- a/lib/web_scraper.dart
+++ b/lib/web_scraper.dart
@@ -174,8 +174,8 @@ class WebScraper {
     // Looping in all the script tags of the document.
     for (var script in scripts) {
       // Regular expression to get the variable name.
-      var re = RegExp(variableName + r""" *=.*?;(?=([^"']*"[^"']*")*[^"']*$)""",
-          multiLine: true);
+      var re =
+          RegExp(variableName + r""" *=.*?;(\r\n|\r|\n)""", multiLine: true);
       //  Find first match
       RegExpMatch? match = re.firstMatch(script.text);
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,28 +7,28 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "16.0.0"
+    version: "43.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "4.3.1"
   args:
     dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.3.1"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -36,69 +36,69 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.2.0"
-  cli_util:
-    dependency: transitive
-    description:
-      name: cli_util
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.3.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   convert:
     dependency: transitive
     description:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.2"
   coverage:
     dependency: transitive
     description:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.15.2"
+    version: "1.5.0"
   crypto:
     dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.2"
   csslib:
     dependency: transitive
     description:
       name: csslib
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.17.0"
+    version: "0.17.2"
   file:
     dependency: transitive
     description:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.0"
+    version: "6.1.2"
+  flutter_lints:
+    dependency: "direct dev"
+    description:
+      name: flutter_lints
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
+  frontend_server_client:
+    dependency: transitive
+    description:
+      name: frontend_server_client
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.3"
   glob:
     dependency: transitive
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   html:
     dependency: "direct main"
     description:
@@ -112,133 +112,140 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.0"
+    version: "0.13.4"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "3.2.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "4.0.1"
   io:
     dependency: transitive
     description:
       name: io
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.4"
+    version: "1.0.3"
   js:
     dependency: transitive
     description:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.4"
+  lints:
+    dependency: transitive
+    description:
+      name: lints
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   logging:
     dependency: transitive
     description:
       name: logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.2"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.12"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.8.0"
   mime:
     dependency: transitive
     description:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.2"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.13"
+    version: "2.0.1"
   package_config:
     dependency: transitive
     description:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   pedantic:
     dependency: "direct dev"
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.1"
   pool:
     dependency: transitive
     description:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.0"
+    version: "1.5.1"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.1"
   shelf:
     dependency: transitive
     description:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.3.2"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.9+2"
+    version: "1.1.1"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.4+1"
+    version: "1.0.2"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -259,7 +266,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
@@ -280,76 +287,76 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test:
     dependency: "direct dev"
     description:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.4"
+    version: "1.21.4"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.4.12"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.14"
+    version: "0.4.16"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.0+1"
+    version: "9.3.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.2.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.5"
+    version: "1.1.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.1.1"
 sdks:
-  dart: ">=2.12.0-259.12.beta <3.0.0"
+  dart: ">=2.17.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,6 @@
 name: web_scraper
-description: A simple web scraper to scrape HTML tags and their attributes to cast them into Lists and Maps for dart and flutter.
+description: A simple web scraper to scrape HTML tags and their attributes to
+  cast them into Lists and Maps for dart and flutter.
 version: 0.1.4
 homepage: https://github.com/tusharojha/web_scraper
 
@@ -8,8 +9,9 @@ environment:
 
 dependencies:
   html: ^0.15.0
-  http: ^0.13.0
+  http: ^0.13.4
 
 dev_dependencies:
-  test: ^1.16.4
-  pedantic: ^1.10.0
+  pedantic: ^1.11.1
+  test: ^1.21.4
+  flutter_lints: ^2.0.0


### PR DESCRIPTION
- Added Flutter Linting and made the recommended changes
- Updated dependencies
- RegExp is now raw String to avoid these backslashes, because they are confusing
- Added `getFirstScriptVariable()` method, because in my use case I only need one
#
- `getFirstScriptVariable()` RegExp is slightly different `varName *=.*?;(?=([^"']*"[^"']*")*[^"']*$)` -> `varName *=.*?;(\r\n|\r|\n)`
- regex101 with html from this page (https://mangasee123.com/read-online/One-Piece-chapter-1-page-1.html)
- Old `varName *=.*?;(?=([^"']*"[^"']*")*[^"']*$)`: **66149 steps**
- New `varName *=.*?;(\r\n|\r|\n)`: **2924 steps**
- What is the difference? - the variable must end with a newLine