### PR TITLE
<enhancement>: updated the version of http package for latest project support

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   html: ^0.15.0
-  http: ^0.13.0
+  http: ^1.1.0
 
 dev_dependencies:
   test: ^1.16.4


### PR DESCRIPTION
changed the version of the `http` package from `^0.13.0` to `^1.1.0` so as to reduce conflicts in newer projects that depend on packages that depend on the latest version of `http` or `http` itself.